### PR TITLE
Fixed typo

### DIFF
--- a/Fountain/Fountain/FTDynamicDataSource.h
+++ b/Fountain/Fountain/FTDynamicDataSource.h
@@ -13,7 +13,7 @@
 @interface FTDynamicDataSource : NSObject <FTDataSource, FTReverseDataSource>
 
 #pragma mark Life-cycle
-- (instancetype)initWithComerator:(NSComparator)comperator;
+- (instancetype)initWithComparator:(NSComparator)comparator;
 
 #pragma mark Relaod
 - (void)reloadWithItems:(NSArray *)sectionItems

--- a/Fountain/Fountain/FTDynamicDataSource.m
+++ b/Fountain/Fountain/FTDynamicDataSource.m
@@ -9,7 +9,7 @@
 #import "FTDynamicDataSource.h"
 
 @interface FTDynamicDataSource ()
-@property (nonatomic, readonly) NSComparator comperator;
+@property (nonatomic, readonly) NSComparator comparator;
 @property (nonatomic, readonly) NSMutableArray *items;
 @end
 
@@ -19,12 +19,12 @@
 
 #pragma mark Life-cycle
 
-- (instancetype)initWithComerator:(NSComparator)comperator
+- (instancetype)initWithComparator:(NSComparator)comparator
 {
     self = [super init];
     if (self) {
         _observers = [NSHashTable weakObjectsHashTable];
-        _comperator = comperator;
+        _comparator = comparator;
         _items = [[NSMutableArray alloc] init];
     }
     return self;
@@ -109,7 +109,7 @@
 
     [self.items removeAllObjects];
     [self.items addObjectsFromArray:items];
-    [self.items sortUsingComparator:self.comperator];
+    [self.items sortUsingComparator:self.comparator];
 
     // Tell all observers to relaod
     // ----------------------------
@@ -253,7 +253,7 @@
 
 - (NSIndexSet *)_insertItems:(NSArray *)items
 {
-    items = [items sortedArrayUsingComparator:self.comperator];
+    items = [items sortedArrayUsingComparator:self.comparator];
 
     NSMutableIndexSet *itemsToInsert = [[NSMutableIndexSet alloc] init];
 
@@ -267,7 +267,7 @@
         NSUInteger index = [self.items indexOfObject:obj
                                        inSortedRange:NSMakeRange(offset, [self.items count] - offset)
                                              options:NSBinarySearchingInsertionIndex
-                                     usingComparator:self.comperator];
+                                     usingComparator:self.comparator];
         [itemsToInsert addIndex:index];
 
         [self.items insertObject:obj atIndex:index];
@@ -308,7 +308,7 @@
 
 - (NSArray *)_updateItems:(NSArray *)items
 {
-    items = [items sortedArrayUsingComparator:self.comperator];
+    items = [items sortedArrayUsingComparator:self.comparator];
 
     __block NSUInteger lastIndex = 0;
 
@@ -324,7 +324,7 @@
         NSUInteger newIndex = [self.items indexOfObject:obj
                                           inSortedRange:NSMakeRange(lastIndex, [self.items count] - lastIndex)
                                                 options:NSBinarySearchingInsertionIndex | NSBinarySearchingFirstEqual
-                                        usingComparator:self.comperator];
+                                        usingComparator:self.comparator];
         [self.items insertObject:obj atIndex:newIndex];
 
         [updates addObject:@[ @(index), @(newIndex) ]];

--- a/Fountain/FountainTests/FTComposedDataSourceSpec.m
+++ b/Fountain/FountainTests/FTComposedDataSourceSpec.m
@@ -26,7 +26,7 @@ describe(@"FTComposedDataSource", ^{
     __block FTComposedDataSource *dataSource = nil;
     
     beforeEach(^{
-        sections = [[FTDynamicDataSource alloc] initWithComerator:^NSComparisonResult(NSDictionary *obj1, NSDictionary *obj2) {
+        sections = [[FTDynamicDataSource alloc] initWithComparator:^NSComparisonResult(NSDictionary *obj1, NSDictionary *obj2) {
             return [[obj1 valueForKey:@"value"] compare:[obj2 valueForKey:@"value"]];
         }];
         
@@ -79,7 +79,7 @@ describe(@"FTComposedDataSource", ^{
             [verifyCount(observer, times(2)) dataSourceDidReload:dataSource];
         });
         
-        it(@"should contain the section items ordered by the comperator", ^{
+        it(@"should contain the section items ordered by the comparator", ^{
             assertThatInteger([dataSource numberOfSections], equalToInteger(10));
             
             assertThat([[dataSource itemForSection:0] valueForKey:@"value"], equalTo(@"a"));
@@ -279,7 +279,7 @@ SpecEnd
 
 - (id<FTDataSource>)createDataSourceWithSectionItem:(NSDictionary *)sectionItem
 {
-    FTDynamicDataSource *dataSource = [[FTDynamicDataSource alloc] initWithComerator:^NSComparisonResult(id obj1, id obj2) {
+    FTDynamicDataSource *dataSource = [[FTDynamicDataSource alloc] initWithComparator:^NSComparisonResult(id obj1, id obj2) {
         return [obj1 compare:obj2];
     }];
     

--- a/Fountain/FountainTests/FTDynamicDataSourceSpec.m
+++ b/Fountain/FountainTests/FTDynamicDataSourceSpec.m
@@ -19,7 +19,7 @@ describe(@"FTDynamicDataSource", ^{
     __block FTDynamicDataSource *dataSource = nil;
     
     beforeEach(^{
-        dataSource = [[FTDynamicDataSource alloc] initWithComerator:^NSComparisonResult(NSDictionary *obj1, NSDictionary *obj2) {
+        dataSource = [[FTDynamicDataSource alloc] initWithComparator:^NSComparisonResult(NSDictionary *obj1, NSDictionary *obj2) {
             return [[obj1 valueForKey:@"value"] compare:[obj2 valueForKey:@"value"]];
         }];
     });
@@ -57,7 +57,7 @@ describe(@"FTDynamicDataSource", ^{
             });
         });
         
-        it(@"should contain the items ordered by the comperator", ^{
+        it(@"should contain the items ordered by the comparator", ^{
             assertThatInteger([dataSource numberOfItemsInSection:0], equalToInteger(10));
             
             NSIndexPath *sectionIndexPath = [NSIndexPath indexPathWithIndex:0];


### PR DESCRIPTION
Spotted and fixed typo in `FTDynamicDataSource` (should be comparator not comperator,comerator)
