### PR TITLE
- fixed crash when _fetchedObjects empty

### DIFF
--- a/FTFountain/Common/FTFetchedDataSource.h
+++ b/FTFountain/Common/FTFetchedDataSource.h
@@ -55,5 +55,6 @@
 // are passing self.predicate AND self.filterPredicate.
 - (BOOL)filterResultWithPredicate:(NSPredicate *)predicate error:(NSError **)error;
 - (void)filterResultWithPredicate:(NSPredicate *)predicate completion:(void (^)(BOOL success, NSError *error))completion;
+- (void)filterFetchedObjectsWithPredicate:(NSPredicate*)predicate;
 
 @end

--- a/FTFountain/Common/FTFetchedDataSource.m
+++ b/FTFountain/Common/FTFetchedDataSource.m
@@ -350,6 +350,11 @@
 
 - (id)itemAtIndexPath:(NSIndexPath *)indexPath
 {
+    if (_fetchedObjects.count == 0)
+    {
+        return nil;
+    }
+    
     return [_fetchedObjects itemAtIndexPath:indexPath];
 }
 

--- a/FTFountain/Common/FTFetchedDataSource.m
+++ b/FTFountain/Common/FTFetchedDataSource.m
@@ -13,6 +13,7 @@
 
 @interface FTFetchedDataSource () <FTDataSourceObserver> {
     NSMutableSet<FTDataSource, FTReverseDataSource> *_fetchedObjects;
+    NSMutableSet<FTDataSource, FTReverseDataSource> *allFetchedObjects;
     NSHashTable *_observers;
     NSPredicate *_filterPredicate;
 }
@@ -118,6 +119,8 @@
                 [observer dataSourceDidReset:self];
             }
         }
+        
+        allFetchedObjects = [_fetchedObjects copy];
 
         return YES;
     } else {
@@ -155,6 +158,8 @@
                 [observer dataSourceDidReset:self];
             }
         }
+        
+        allFetchedObjects = [_fetchedObjects copy];
 
         if (completion) {
             completion(YES, nil);
@@ -176,6 +181,23 @@
 }
 
 #pragma mark Filter Result
+
+- (void)filterFetchedObjectsWithPredicate:(NSPredicate*)predicate
+{
+    FTMutableSet *newFechtedObjects = [allFetchedObjects mutableCopy];
+    
+    [newFechtedObjects filterUsingPredicate:predicate ?: [NSPredicate predicateWithValue:YES]];
+    
+    if ([_fetchedObjects isKindOfClass:[FTMutableSet class]]) {
+        
+        FTMutableSet *fetchedObjects = (FTMutableSet *)_fetchedObjects;
+        [fetchedObjects removeAllObjects];
+        
+        [fetchedObjects performBatchUpdate:^{
+            [fetchedObjects addObjectsFromArray:newFechtedObjects.allObjects];
+        }];
+    }
+}
 
 - (BOOL)filterResultWithPredicate:(NSPredicate *)predicate
                             error:(NSError **)error

--- a/FTFountain/Common/FTFetchedDataSource.m
+++ b/FTFountain/Common/FTFetchedDataSource.m
@@ -351,6 +351,8 @@
             }];
         }
     }
+    
+    allFetchedObjects = [_fetchedObjects copy];
 }
 
 #pragma mark FTDataSource

--- a/FTFountain/Common/FTFetchedDataSource.m
+++ b/FTFountain/Common/FTFetchedDataSource.m
@@ -213,16 +213,18 @@
         if ([_fetchedObjects isKindOfClass:[FTMutableSet class]]) {
             
             FTMutableSet *fetchedObjects = (FTMutableSet *)_fetchedObjects;
+            [fetchedObjects removeAllObjects];
+
             [fetchedObjects performBatchUpdate:^{
-                [fetchedObjects removeAllObjects];
                 [fetchedObjects addObjectsFromArray:result];
             }];
             
         } else if ([_fetchedObjects isKindOfClass:[FTMutableClusterSet class]]) {
             
             FTMutableClusterSet *fetchedObjects = (FTMutableClusterSet *)_fetchedObjects;
+            [fetchedObjects removeAllObjects];
+
             [fetchedObjects performBatchUpdate:^{
-                [fetchedObjects removeAllObjects];
                 [fetchedObjects addObjectsFromArray:result];
             }];
             
@@ -250,16 +252,18 @@
         if ([_fetchedObjects isKindOfClass:[FTMutableSet class]]) {
             
             FTMutableSet *fetchedObjects = (FTMutableSet *)_fetchedObjects;
+            [fetchedObjects removeAllObjects];
+
             [fetchedObjects performBatchUpdate:^{
-                [fetchedObjects removeAllObjects];
                 [fetchedObjects addObjectsFromArray:result.finalResult];
             }];
             
         } else if ([_fetchedObjects isKindOfClass:[FTMutableClusterSet class]]) {
             
             FTMutableClusterSet *fetchedObjects = (FTMutableClusterSet *)_fetchedObjects;
+            [fetchedObjects removeAllObjects];
+
             [fetchedObjects performBatchUpdate:^{
-                [fetchedObjects removeAllObjects];
                 [fetchedObjects addObjectsFromArray:result.finalResult];
             }];
             


### PR DESCRIPTION
The introduced changes fix crashes in vanilla Fountain and add the possibility to filter through fetchedObjects without fetching.
