### PR TITLE
Skip item reloading

### DIFF
--- a/FTFountain/iOS/FTCollectionViewAdapter.h
+++ b/FTFountain/iOS/FTCollectionViewAdapter.h
@@ -39,4 +39,8 @@ typedef void (^FTCollectionViewAdapterCellPrepareBlock)(id cell, id item, NSInde
          useViewWithReuseIdentifier:(NSString *)reuseIdentifier
                        prepareBlock:(FTCollectionViewAdapterCellPrepareBlock)prepareBlock;
 
+#pragma mark - UI
+
+@property BOOL shouldSkipReloadOfUpdatedItems;
+
 @end

--- a/FTFountain/iOS/FTCollectionViewAdapter.m
+++ b/FTFountain/iOS/FTCollectionViewAdapter.m
@@ -430,7 +430,7 @@
 
 - (void)dataSource:(id<FTDataSource>)dataSource didChangeItemsAtIndexPaths:(NSArray *)indexPaths
 {
-    if (_isInUserDrivenChangeCallCount == 0 && dataSource == _dataSource) {
+    if (_isInUserDrivenChangeCallCount == 0 && dataSource == _dataSource && !_shouldSkipReloadOfUpdatedItems) {
         [_reloadedItems addObjectsFromArray:indexPaths];
     }
 }

--- a/FTFountain/iOS/FTTableViewAdapter.h
+++ b/FTFountain/iOS/FTTableViewAdapter.h
@@ -55,4 +55,8 @@ typedef NSDictionary * (^FTTableViewAdapterCellPropertiesBlock)(id cell, NSIndex
 #pragma mark Cell Properties
 @property (nonatomic, strong) FTTableViewAdapterCellPropertiesBlock cellPropertiesBlock;
 
+#pragma mark - UI
+
+@property BOOL shouldSkipReloadOfUpdatedItems;
+
 @end

--- a/FTFountain/iOS/FTTableViewAdapter.m
+++ b/FTFountain/iOS/FTTableViewAdapter.m
@@ -536,7 +536,7 @@
 
 - (void)dataSource:(id<FTDataSource>)dataSource didChangeItemsAtIndexPaths:(NSArray *)indexPaths
 {
-    if (_isInUserDrivenChangeCallCount == 0 && dataSource == _dataSource) {
+    if (_isInUserDrivenChangeCallCount == 0 && dataSource == _dataSource && !_shouldSkipReloadOfUpdatedItems) {
         [_tableView reloadRowsAtIndexPaths:indexPaths withRowAnimation:self.rowAnimation];
     }
 }


### PR DESCRIPTION
Let me please explain why we have this change.
We had to implement a different, unified Data Source for our two functionalities, that use the same source.
The constant reloading of items using our and FTFetchedDataSource was causing weird UI behaviours on some of our collection view header items.
With this approach and using our data source, we are able to add and remove items, without reloading those that are not being changed.

We are also eager to hearing from you regarding a different approach using Fountain.
